### PR TITLE
enforce UTF8 sending

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.common",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "The common module for AutoRest Extensions",
   "scripts": {
     "test": "gulp test",


### PR DESCRIPTION
...since dotnet 2.0 seems to have changed the encoding of `Console.Out`