### PR TITLE
fix name collision detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.common",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "The common module for AutoRest Extensions",
   "scripts": {
     "test": "gulp test",

--- a/src/CodeNamer.cs
+++ b/src/CodeNamer.cs
@@ -456,7 +456,7 @@ namespace AutoRest.Core
                     desiredName));
             }
 
-            if (ReservedWords.Contains(desiredName))
+            if (ReservedWords.Contains(desiredName, StringComparer.OrdinalIgnoreCase))
             {
                 return desiredName;
             }


### PR DESCRIPTION
property called `ref` in Swagger => property `Ref` in C# was checked against reserved keywords => no collision => constructor parameter called `ref`