### PR TITLE
Update Nuget package metadata

### DIFF
--- a/src/autorest.common.csproj
+++ b/src/autorest.common.csproj
@@ -2,17 +2,30 @@
   <PropertyGroup><PowerShell># 2&gt;nul || type %~df0|C:\Windows\system32\find.exe /v "setlocal"|C:\Windows\system32\find.exe /v "errorlevel"|powershell.exe -noninteractive -&amp; exit %errorlevel% || #</PowerShell></PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <GenerateFullPaths>true</GenerateFullPaths>
-    <Common>$(MsBuildThisFileDirectory)</Common>
-    <SolutionDir>$(Common)../</SolutionDir>
- 
-    <Copyright>Copyright (c) Microsoft Corporation</Copyright>
-
+    <PackageId>Microsoft.AutoRest.Common</PackageId>
+    <AssemblyName>Microsoft.AutoRest.Common</AssemblyName>
+    <AssemnblyTitle>Microsoft AutoRest Common</AssemnblyTitle>
+    <Version>2.4.37</Version>
+    <Description>PLEASE PROVIDE DESCRIPTION about your pacakge</Description>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <Authors>Microsoft</Authors>
+    <Owners>Microsoft, azure-sdk</Owners>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Azure/AutoRest</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <RepositoryUrl>https://github.com/Azure/autorest.common</RepositoryUrl>    
+    <PackageTags>autorest.common;AutoRest</PackageTags>
+    <PacakgeReleaseNotes>
+      <![CDATA[
+        1. Current Release specific notes
+      ]]>
+    </PacakgeReleaseNotes>
+  </PropertyGroup>
+  <PropertyGroup>
+    <GenerateFullPaths>true</GenerateFullPaths>
+    <Common>$(MsBuildThisFileDirectory)</Common>
+    <SolutionDir>$(Common)../</SolutionDir> 
     
     <!-- 
     <DelaySign Condition="$(Configuration) == 'Release'">true</DelaySign>
@@ -22,11 +35,8 @@
     -->
 
     <OutputType>library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>autorest.common</AssemblyName>
-    <PackageTags>autorest.common</PackageTags>
-    <RootNamespace>AutoRest.Common</RootNamespace>
- 
+    <TargetFramework>netstandard2.0</TargetFramework>    
+    <RootNamespace>Microsoft.AutoRest.Common</RootNamespace>
     <BaseOutputPath>$(MSBuildProjectDirectory)/bin</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)</OutputPath>
   </PropertyGroup>

--- a/src/autorest.common.csproj
+++ b/src/autorest.common.csproj
@@ -5,8 +5,8 @@
     <PackageId>Microsoft.AutoRest.Common</PackageId>
     <AssemblyName>Microsoft.AutoRest.Common</AssemblyName>
     <AssemnblyTitle>Microsoft AutoRest Common</AssemnblyTitle>
-    <Version>2.4.37</Version>
-    <Description>PLEASE PROVIDE DESCRIPTION about your pacakge</Description>
+    <Version>1.0.0</Version>
+    <Description>Common code shared between AutoRest modeler and code generators</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft, azure-sdk</Owners>
@@ -18,11 +18,9 @@
     <PackageTags>autorest.common;AutoRest</PackageTags>
     <PacakgeReleaseNotes>
       <![CDATA[
-        1. Current Release specific notes
+        1. Provides common code
       ]]>
     </PacakgeReleaseNotes>
-  </PropertyGroup>
-  <PropertyGroup>
     <GenerateFullPaths>true</GenerateFullPaths>
     <Common>$(MsBuildThisFileDirectory)</Common>
     <SolutionDir>$(Common)../</SolutionDir> 


### PR DESCRIPTION
Updating package meta data that is required to following guidelines in order for packages to be published to nuget.org
Added place holder for missing description and package release notes.
