### PR TITLE
Add check if type to delete exists

### DIFF
--- a/src/SwaggerExtensions.cs
+++ b/src/SwaggerExtensions.cs
@@ -283,7 +283,11 @@ namespace AutoRest.Extensions
                 string typeName = typeNames.First();
                 typeNames.Remove(typeName);
 
-                var typeToDelete = codeModel.ModelTypes.First(t => t.Name == typeName);
+                var typeToDelete = codeModel.ModelTypes.FirstOrDefault(t => t.Name == typeName);
+
+                if (typeToDelete == null) {
+                    return;
+                }
 
                 var isUsedInErrorTypes = codeModel.ErrorTypes.Any(e => e.Name == typeName);
                 var isUsedInResponses = codeModel.Methods.Any(m => m.Responses.Any(r => typeReferenced(typeToDelete, r.Value.Body)));


### PR DESCRIPTION
This fixes following problem in JS SDK(Resolves https://github.com/Azure/azure-sdk-for-js/issues/500):

```
> gulp codegen --package @azure/arm-rediscache
[18:07:44] Requiring external module ts-node/register
[18:07:45] Using gulpfile ~/Repos/azure-sdk-for-js/gulpfile.ts
(node:93690) ExperimentalWarning: The fs.promises API is experimental
[18:07:45] Starting 'codegen'...
Passed arguments: codegen, --package, @azure/arm-rediscache
>>>>>>>>>>>>>>>>>>> Start: "["@azure/arm-rediscache"]" >>>>>>>>>>>>>>>>>>>>>>>>>
Executing command:
------------------------------------------------------------
autorest --typescript --typescript-sdks-folder=/Users/kamip/Repos/azure-sdk-for-js --license-header=MICROSOFT_MIT_NO_VERSION /Users/kamip/Repos/azure-rest-api-specs/specification/redis/resource-manager/readme.md --use=/Users/kamip/Repos/autorest.typescript
------------------------------------------------------------
FATAL: System.InvalidOperationException: Sequence contains no matching element
   at System.Linq.Enumerable.First[TSource](IEnumerable1 source, Func2 predicate)
   at AutoRest.Extensions.SwaggerExtensions.RemoveUnreferencedTypes(CodeModel codeModel, HashSet`1 typeNames) in /Users/kamip/Repos/autorest.typescript/autorest.common/src/SwaggerExtensions.cs:line 286
   at AutoRest.Extensions.SwaggerExtensions.FlattenModels(CodeModel codeModel) in /Users/kamip/Repos/autorest.typescript/autorest.common/src/SwaggerExtensions.cs:line 108
   at AutoRest.Extensions.Azure.AzureExtensions.NormalizeAzureClientModel(CodeModel codeModel) in /Users/kamip/Repos/autorest.typescript/autorest.common/src/AzureExtensions.cs:line 78
   at AutoRest.TypeScript.Azure.TransformerTSa.AutoRest.Core.ITransformer<AutoRest.TypeScript.Azure.Model.CodeModelTSa>.TransformCodeModel(CodeModel cm) in /Users/kamip/Repos/autorest.typescript/src/azure/TransformerTSa.cs:line 35
   at AutoRest.TypeScript.Program.<ProcessInternal>d__4.MoveNext() in /Users/kamip/Repos/autorest.typescript/src/Program.cs:line 100
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at NewPlugin.<Process>d__20.MoveNext() in /Users/kamip/Repos/autorest.typescript/autorest.common/src/Plugins/NewPlugin.cs:line 163
FATAL: typescript/generate - FAILED
FATAL: Error: Plugin typescript reported failure.
  Error: Plugin typescript reported failure.
Error:
An error occurred while generating client for packages: "["@azure/arm-rediscache"]":
Err: Error: Command failed: autorest --typescript --typescript-sdks-folder=/Users/kamip/Repos/azure-sdk-for-js --license-header=MICROSOFT_MIT_NO_VERSION /Users/kamip/Repos/azure-rest-api-specs/specification/redis/resource-manager/readme.md --use=/Users/kamip/Repos/autorest.typescript
FATAL: System.InvalidOperationException: Sequence contains no matching element
   at System.Linq.Enumerable.First[TSource](IEnumerable1 source, Func2 predicate)
   at AutoRest.Extensions.SwaggerExtensions.RemoveUnreferencedTypes(CodeModel codeModel, HashSet`1 typeNames) in /Users/kamip/Repos/autorest.typescript/autorest.common/src/SwaggerExtensions.cs:line 286
   at AutoRest.Extensions.SwaggerExtensions.FlattenModels(CodeModel codeModel) in /Users/kamip/Repos/autorest.typescript/autorest.common/src/SwaggerExtensions.cs:line 108
   at AutoRest.Extensions.Azure.AzureExtensions.NormalizeAzureClientModel(CodeModel codeModel) in /Users/kamip/Repos/autorest.typescript/autorest.common/src/AzureExtensions.cs:line 78
   at AutoRest.TypeScript.Azure.TransformerTSa.AutoRest.Core.ITransformer<AutoRest.TypeScript.Azure.Model.CodeModelTSa>.TransformCodeModel(CodeModel cm) in /Users/kamip/Repos/autorest.typescript/src/azure/TransformerTSa.cs:line 35
   at AutoRest.TypeScript.Program.<ProcessInternal>d__4.MoveNext() in /Users/kamip/Repos/autorest.typescript/src/Program.cs:line 100
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at NewPlugin.<Process>d__20.MoveNext() in /Users/kamip/Repos/autorest.typescript/autorest.common/src/Plugins/NewPlugin.cs:line 163
FATAL: typescript/generate - FAILED
FATAL: Error: Plugin typescript reported failure.
  Error: Plugin typescript reported failure.

Stderr: "FATAL: System.InvalidOperationException: Sequence contains no matching element
   at System.Linq.Enumerable.First[TSource](IEnumerable1 source, Func2 predicate)
   at AutoRest.Extensions.SwaggerExtensions.RemoveUnreferencedTypes(CodeModel codeModel, HashSet`1 typeNames) in /Users/kamip/Repos/autorest.typescript/autorest.common/src/SwaggerExtensions.cs:line 286
   at AutoRest.Extensions.SwaggerExtensions.FlattenModels(CodeModel codeModel) in /Users/kamip/Repos/autorest.typescript/autorest.common/src/SwaggerExtensions.cs:line 108
   at AutoRest.Extensions.Azure.AzureExtensions.NormalizeAzureClientModel(CodeModel codeModel) in /Users/kamip/Repos/autorest.typescript/autorest.common/src/AzureExtensions.cs:line 78
   at AutoRest.TypeScript.Azure.TransformerTSa.AutoRest.Core.ITransformer<AutoRest.TypeScript.Azure.Model.CodeModelTSa>.TransformCodeModel(CodeModel cm) in /Users/kamip/Repos/autorest.typescript/src/azure/TransformerTSa.cs:line 35
   at AutoRest.TypeScript.Program.<ProcessInternal>d__4.MoveNext() in /Users/kamip/Repos/autorest.typescript/src/Program.cs:line 100
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at NewPlugin.<Process>d__20.MoveNext() in /Users/kamip/Repos/autorest.typescript/autorest.common/src/Plugins/NewPlugin.cs:line 163
FATAL: typescript/generate - FAILED
FATAL: Error: Plugin typescript reported failure.
  Error: Plugin typescript reported failure.
"
>>>>>>>>>>>>>>>>>>> End: "["@azure/arm-rediscache"]" >>>>>>>>>>>>>>>>>>>>>>>>>
undefined
[18:07:53] Finished 'codegen' after 7.99 s
```