### PR TITLE
Keep Query params when creating a Next paging operation

### DIFF
--- a/src/AzureExtensions.cs
+++ b/src/AzureExtensions.cs
@@ -369,7 +369,7 @@ namespace AutoRest.Extensions.Azure
                         nextLinkMethod.Add(nextLinkParameter);
 
                         // Need copy all the header parameters from List method to ListNext method
-                       foreach (var param in method.Parameters.Where(p => p.Location == ParameterLocation.Header))
+                       foreach (var param in method.Parameters.Where(p => p.Location == ParameterLocation.Header || p.Location == ParameterLocation.Query))
                        {
                             nextLinkMethod.Add(Duplicate(param));
                        }


### PR DESCRIPTION
**Context**
- Pageable operations are cloned to create a new OperationNext operation which contains the configuration to make the call to get the next page, generally using a nextLink

**Problem:**
When cloning the original operation we're clearing all the parameters and later on bringing back in only the HeaderParameters this is causing us to miss required QueryParameters such as `api-version` in this issue https://github.com/Azure/autorest.typescript/issues/770

**Fix:**
In addition to Header parameters also clone the Query parameters